### PR TITLE
Updated to show how can download directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ mv ~/Downloads/anbox-session-manager.service ~/.config/systemd/user/anbox-sessio
 systemctl --user enable --now anbox-session-manager
 ```
 
+or alternatively you can download it directly
+```
+mkdir -p ~/.config/systemd/user
+wget -O ~/.config/systemd/user/anbox-session-manager.service https://raw.githubusercontent.com/Fuseteam/systemd-service-files/main/user/anbox-session-manager.service
+systemctl --user enable --now anbox-session-manager
+```
+
 you can check if anbox's session-manager is running properly with 
 ```
 systemctl --user status anbox-session-manager


### PR DESCRIPTION
Updated with an optional way to to download it directly where it is needed after folder exists.

Thanks for this awesome snippet was seeing it referenced everywhere but couldn't find it in the snap install files and was curious where it came from and finally stumbled onto a link to it here.